### PR TITLE
chore(travis): Remove g++-4.8 env. This is only for old phantomjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,6 @@ cache:
   directories:
   - node_modules
 
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
-
 git:
   depth: 1
 


### PR DESCRIPTION
Now we use phantomjs-prebuilt, I think we don't need it.